### PR TITLE
ci: add manual npm release workflow via semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run prepublishOnly
+
+      - name: Release
+        run: npm run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

No way to publish this package to npm from CI. Manual `npm publish` is awkward with 2FA enabled, since it prompts for an OTP.

## Solution

Add a `workflow_dispatch`-only GitHub Action (no auto-trigger on push/merge) that runs `semantic-release`, which is already configured in `.releaserc.json`. Publishing goes through npm's OIDC trusted publishing via `@semantic-release/npm`, so no `NPM_TOKEN` secret is needed, just the `id-token: write` permission on the job.

Requires adding a Trusted Publisher entry for this repo/workflow on the npm package's settings page before first use.
