### PR TITLE
ci: match release-please tags to existing v-prefixed tag format

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "node",
   "packages": {
     ".": {
+      "include-component-in-tag": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Problem

PR #597 (the first release-please PR) includes changelog entries for features and fixes already shipped in 1.4.0 and earlier. release-please defaults to component-prefixed tags (`homebridge-smartrent-v1.5.0`), which don't match the plain `v1.4.0`/`v1.3.1`/... tags the old semantic-release setup created. Unable to find a matching prior tag, it treated the entire 1408-commit history as unreleased.

## Solution

Set `include-component-in-tag: false` in `release-please-config.json` so generated tags stay in the existing `v${version}` format, letting release-please correctly recognize `v1.4.0` as the last release and scope the changelog to commits since then.
